### PR TITLE
Add module and top const ref support

### DIFF
--- a/src/printer/index.js
+++ b/src/printer/index.js
@@ -113,6 +113,18 @@ function genericPrint(path, options, print) {
   }
 
   switch (n.ast_type) {
+    case "module": {
+      const name = path.call(print, "name");
+      let parts = [];
+      parts.push("module ");
+      parts.push(name);
+      parts = [group(concat(parts))];
+
+      const body = path.call(print, "body");
+      parts.push(indent(concat([hardline, body])), hardline, "end");
+      return concat(parts);
+    }
+
     case "class": {
       const name = path.call(print, "name");
       const superClass = path.call(print, "superclass");
@@ -124,10 +136,7 @@ function genericPrint(path, options, print) {
       }
       parts = [group(concat(parts))];
       const body = path.call(print, "body");
-      parts.push(
-        indent(concat([hardline, body])),
-        dedent(concat([hardline, "end"]))
-      );
+      parts.push(indent(concat([hardline, body])), hardline, "end");
       return concat(parts);
     }
 
@@ -332,6 +341,10 @@ function genericPrint(path, options, print) {
 
     case "bare_assoc_hash": {
       return join(concat([",", line]), path.map(print, "hashes"));
+    }
+
+    case "top_const_ref": {
+      return concat(["::", path.call(print, "value")]);
     }
 
     case "const_path_ref": {

--- a/tests/module/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/module/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`module_1.rb 1`] = `
+module ::A::B::C
+  module NestedModule::Foo
+    class ClassName
+      def add(x, y)
+        x + y
+      end
+    end
+  end
+end
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+module ::A::B::C
+  module NestedModule::Foo
+    class ClassName
+      def add(x, y)
+        x + y
+      end
+    end
+  end
+end
+
+`;

--- a/tests/module/jsfmt.spec.js
+++ b/tests/module/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["ruby"]);

--- a/tests/module/module_1.rb
+++ b/tests/module/module_1.rb
@@ -1,0 +1,9 @@
+module ::A::B::C
+  module NestedModule::Foo
+    class ClassName
+      def add(x, y)
+        x + y
+      end
+    end
+  end
+end

--- a/vendor/ruby/astexport.rb
+++ b/vendor/ruby/astexport.rb
@@ -30,6 +30,10 @@ class Processor
     when :program
       body = visit_exps(node[1])
       { ast_type: 'program', body: body }
+    when :module
+      # ["module", const_path_ref, bodystmt]
+      type, name, body = node
+      { ast_type: type, name: visit(name), body: visit(body) }
     when :class
       visit_class(node)
     when :assign
@@ -90,6 +94,10 @@ class Processor
       { ast_type: type, value: value }
     when :const_ref
       # [:const_ref, [:@const, "Foo", [1, 8]]]
+      type, value = node
+      { ast_type: type, value: visit(value) }
+    when :top_const_ref
+      # [:top_const_ref, [:@const, ...]]
       type, value = node
       { ast_type: type, value: visit(value) }
     when :void_stmt


### PR DESCRIPTION
Hey; I tried running prettier-ruby with some local Ruby files and I noticed there wasn't module or top const ref support - so I decided to give it a go! :)

It's not quite there yet, but I'll apply any feedback you have :+1: