### PR TITLE
No longer crash when a function call has no arguments

### DIFF
--- a/src/printer/index.js
+++ b/src/printer/index.js
@@ -587,6 +587,12 @@ function genericPrint(path, options, print) {
     }
 
     case "method_add_arg": {
+      if (n.args.args == null) {
+        return concat([
+          path.call(print, "name")
+        ]);
+      }
+
       return concat([
         path.call(print, "name"),
         "(",

--- a/tests/if/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/if/__snapshots__/jsfmt.spec.js.snap
@@ -31,3 +31,19 @@ end
 puts 'this is true' if true
 
 `;
+
+exports[`if_3.rb 1`] = `
+def foo()
+  true
+end
+
+if foo()
+  puts "this is true"
+end
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+def foo
+  true
+end
+puts 'this is true' if foo
+
+`;

--- a/tests/if/if_3.rb
+++ b/tests/if/if_3.rb
@@ -1,0 +1,7 @@
+def foo()
+  true
+end
+
+if foo()
+  puts "this is true"
+end

--- a/vendor/ruby/astexport.rb
+++ b/vendor/ruby/astexport.rb
@@ -141,7 +141,9 @@ class Processor
     when :var_ref
       { ast_type: 'var_ref', ref: visit(node[1]) }
     when :arg_paren
-      { ast_type: 'arg_paren', args: visit(node[1]) }
+      type, args = node
+
+      { ast_type: type, args: (args.nil? ? nil : visit(args)) }
     when :args_add_block
       { ast_type: 'args_add_block', args_body: visit_exps(node[1]) }
     when :vcall


### PR DESCRIPTION
Adding an example for a function being called with no arguments, as well as fixing the corresponding crash:

```
~/prettier-ruby/vendor/ruby/astexport.rb:29:in `visit': undefined method `first' for nil:NilClass (NoMethodError)
  from ~/prettier-ruby/vendor/ruby/astexport.rb:138:in `visit'
  from ~/prettier-ruby/vendor/ruby/astexport.rb:123:in `visit'
  from ~/prettier-ruby/vendor/ruby/astexport.rb:645:in `visit_if'
  from ~/prettier-ruby/vendor/ruby/astexport.rb:194:in `visit'
  from ~/prettier-ruby/vendor/ruby/astexport.rb:477:in `block in visit_exps'
  from ~/prettier-ruby/vendor/ruby/astexport.rb:475:in `each'
  from ~/prettier-ruby/vendor/ruby/astexport.rb:475:in `visit_exps'
  from ~/prettier-ruby/vendor/ruby/astexport.rb:31:in `visit'
  from ~/prettier-ruby/vendor/ruby/astexport.rb:11:in `initialize'
  from ~/prettier-ruby/vendor/ruby/astexport.rb:733:in `new'
  from ~/prettier-ruby/vendor/ruby/astexport.rb:733:in `<main>'
```