### PR TITLE
Add missing command call support

### DIFF
--- a/src/printer/index.js
+++ b/src/printer/index.js
@@ -382,6 +382,16 @@ function genericPrint(path, options, print) {
       return concat(bodyStatementParts);
     }
 
+    case "command_call": {
+      return concat([
+        path.call(print, "receiver"),
+        n.separator,
+        path.call(print, "name"),
+        " ",
+        path.call(print, "args")
+      ]);
+    }
+
     case "command": {
       const body = path.call(print, "args");
       let finalBody = group(concat(["(", body, ")"]));

--- a/tests/ruby_call/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/ruby_call/__snapshots__/jsfmt.spec.js.snap
@@ -2,10 +2,14 @@
 
 exports[`call_1.rb 1`] = `
 puts 123
+['small', 'medium', 'large'].include? params[:size]
+params&.include? params[:size]
 
 greet('userName')
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 puts 123
+['small', 'medium', 'large'].include? params[:size]
+params&.include? params[:size]
 greet('userName')
 
 `;

--- a/tests/ruby_call/call_1.rb
+++ b/tests/ruby_call/call_1.rb
@@ -1,3 +1,5 @@
 puts 123
+['small', 'medium', 'large'].include? params[:size]
+params&.include? params[:size]
 
 greet('userName')

--- a/vendor/ruby/astexport.rb
+++ b/vendor/ruby/astexport.rb
@@ -194,6 +194,11 @@ class Processor
       visit_while_mod(node)
     when :command
       visit_command(node)
+    when :command_call
+      # Note that the seperator can either be :"." or :"&."
+      type, receiver, separator, name, args = node
+
+      { ast_type: type, receiver: visit(receiver), separator: separator, name: visit(name), args: visit(args) }
     when :assoc_new
       visit_hash_key_value(node)
     when :until


### PR DESCRIPTION
Add support for command call support:

```ruby
['small', 'medium', 'large'].include? params[:size]
params&.include? params[:size]
```

Closes https://github.com/iamsolankiamit/prettier-ruby/issues/10