### PR TITLE
Add support for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,17 +8,10 @@ cache:
   yarn: true
   directories:
   - node_modules
-  - /home/travis/.pyenv_cache
+notifications:
+  email: false
 install:
   - yarn install
-before_install:
-  - export PYTHON_BUILD_CACHE_PATH="/home/travis/.pyenv_cache"
-  - curl -L https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | bash
-  - export PATH="/home/travis/.pyenv/bin:$PATH"
-  - eval "$(pyenv init -)"
-  - eval "$(pyenv virtualenv-init -)"
-  - pyenv install -s 2.7.11
-  - pyenv install -s 3.6.3
-  - pyenv global 2.7.11 3.6.3
 script:
-  - AST_COMPARE=1 yarn test -- --runInBand
+  - echo $(ruby --version)
+  - yarn run test


### PR DESCRIPTION
Update the existing `.travis.yml` script to support running the tests for prettier-ruby.

I have this working on my own fork of prettier-ruby [here](https://travis-ci.org/AlanFoster/prettier-ruby/jobs/387422403), for evidence of it working:

<img width="840" alt="image" src="https://user-images.githubusercontent.com/1271782/40887949-2be8df9a-6748-11e8-80dd-f0630b156fb4.png">

@iamsolankiamit It should be pretty easy to turn this on for the original repository by visiting https://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI and completing the first two steps 🤞 

closes https://github.com/iamsolankiamit/prettier-ruby/issues/7