### PR TITLE
Disable max nesting for pretty generate

### DIFF
--- a/vendor/ruby/astexport.rb
+++ b/vendor/ruby/astexport.rb
@@ -824,4 +824,4 @@ result[:tokens] = processor.tokens.reverse.pretty_inspect if ENV['DEBUG']
 result[:sexp] = processor.sexp.pretty_inspect if ENV['DEBUG']
 result[:json] = processor.json
 
-puts JSON.pretty_generate(result)
+puts JSON.pretty_generate(result, max_nesting: false)


### PR DESCRIPTION
I noticed that the JSON dumper for the AST exporter has a maximum limit:

> yarn prettier vendor/ruby/astexport.rb
> ...
> Error: ~/.rvm/gems/ruby-2.3.1/gems/json-2.1.0/lib/json/common.rb:286:in `generate': nesting of 100 is too deep (JSON::NestingError)

After this PR:

> yarn prettier vendor/ruby/astexport.rb
>✨  Done in 0.61s

In the future a more lightweight data-structure could be used, but I think this is the right decision for now