### PR TITLE
Remove extra trailing slash for regex

### DIFF
--- a/src/printer/index.js
+++ b/src/printer/index.js
@@ -755,7 +755,6 @@ function genericPrint(path, options, print) {
       return concat([
         "/",
         join("", path.map(print, "content")),
-        "/",
         path.call(print, "regexp_end")
       ]);
 

--- a/tests/regexp/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/regexp/__snapshots__/jsfmt.spec.js.snap
@@ -2,7 +2,34 @@
 
 exports[`regexp.rb 1`] = `
 /\\A[\\w+-_]+\\Z/mi
+/foo/u
+/foo/e
+/foo/s
+/foo/n
+/foo/i
+
+/foo(bar)/
+
+float_pat = /\\A
+    [[:digit:]]+ # 1 or more digits before the decimal point
+    (\\.          # Decimal point
+        [[:digit:]]+ # 1 or more digits after the decimal point
+    )? # The decimal point and following digits are optional
+\\Z/x
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/\\A[\\w+-_]+\\Z//mi
+/\\A[\\w+-_]+\\Z/mi
+/foo/u
+/foo/e
+/foo/s
+/foo/n
+/foo/i
+/foo(bar)/
+float_pat =
+  /\\A
+    [[:digit:]]+ # 1 or more digits before the decimal point
+    (\\.          # Decimal point
+        [[:digit:]]+ # 1 or more digits after the decimal point
+    )? # The decimal point and following digits are optional
+\\Z/x
 
 `;

--- a/tests/regexp/regexp.rb
+++ b/tests/regexp/regexp.rb
@@ -1,1 +1,15 @@
 /\A[\w+-_]+\Z/mi
+/foo/u
+/foo/e
+/foo/s
+/foo/n
+/foo/i
+
+/foo(bar)/
+
+float_pat = /\A
+    [[:digit:]]+ # 1 or more digits before the decimal point
+    (\.          # Decimal point
+        [[:digit:]]+ # 1 or more digits after the decimal point
+    )? # The decimal point and following digits are optional
+\Z/x


### PR DESCRIPTION
There was an extra trailing slash being added to regular expressions. It turns out that the sexpressions contain a trailing slash already:

```json
{
    "ast_type": "regexp_literal",
    "content": [
        {
            "ast_type": "@tstring_content",
            "content": "foo(bar)"
        }
    ],
    "regexp_end": {
        "ast_type": "@regexp_end",
        "regexp_end": "/"
    }
},
```