### PR TITLE
Support string concat syntax

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,2 @@
+# Prettier uses the default configuration, so the config file is empty to prevent custom
+# defaults overriding the Prettier defaults

--- a/src/printer/index.js
+++ b/src/printer/index.js
@@ -868,6 +868,14 @@ function genericPrint(path, options, print) {
       return concat(["#{", concat(path.map(print, "interpolations")), "}"]);
     }
 
+    case "string_concat": {
+      return concat([
+        path.call(print, "left"),
+        " \\",
+        indent(concat([hardline, path.call(print, "right")]))
+      ]);
+    }
+
     case "return0":
     case "return": {
       const value = path.call(print, "value");

--- a/tests/strings/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/strings/__snapshots__/jsfmt.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`strings.rb 1`] = `
+exports[`strings.rb - ruby-verify: strings.rb 1`] = `
 'hello world'
 "hello world"
 
@@ -9,6 +9,13 @@ exports[`strings.rb 1`] = `
 
 'hello\\nworld1'
 "hello\\nworld2"
+
+"hello " \\
+  "world"
+
+'hello ' \\
+  'world ' \\
+  'multiline'
 
 '\\n'
 "\\\\n"
@@ -33,6 +40,13 @@ exports[`strings.rb 1`] = `
 
 'hello\\nworld1'
 "hello\\nworld2"
+
+'hello ' \\
+  'world'
+
+'hello ' \\
+  'world ' \\
+  'multiline'
 
 '\\n'
 "\\\\n"

--- a/tests/strings/strings.rb
+++ b/tests/strings/strings.rb
@@ -7,6 +7,13 @@
 'hello\nworld1'
 "hello\nworld2"
 
+"hello " \
+  "world"
+
+'hello ' \
+  'world ' \
+  'multiline'
+
 '\n'
 "\\n"
 "\n"

--- a/vendor/ruby/astexport.rb
+++ b/vendor/ruby/astexport.rb
@@ -354,6 +354,8 @@ class Processor
       { ast_type: type, regexp_end: regexp_end }
     when :string_literal, :xstring_literal
       visit_string_literal(node)
+    when :string_concat
+      visit_string_concat(node)
     when :string_content
       # [:string_content, exp]
       _, *exps = node
@@ -1027,6 +1029,11 @@ class Processor
       json[:here_doc_end] = hereDocEnd
     end
     json
+  end
+
+  def visit_string_concat(node)
+    type, left, right = node
+    { ast_type: type, left: visit(left), right: visit(right) }
   end
 
   def visit_unary(node)


### PR DESCRIPTION
Adds support for `string_concat` syntax from issue #43.

Also adds a blank `.prettierrc` file to the repo to prevent people with altered defaults from restyling all the JS.

This is my first contribution, so let me know if I've missed anything in how the code works or the procedures for PRs!