### PR TITLE
Array destructuring and constructing with splats

### DIFF
--- a/tests/array/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/array/__snapshots__/jsfmt.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`empty_array.rb 1`] = `
+exports[`empty_array.rb - ruby-verify: empty_array.rb 1`] = `
 empty_array = []
 empty_array
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -9,7 +9,7 @@ empty_array
 
 `;
 
-exports[`number_array.rb 1`] = `
+exports[`number_array.rb - ruby-verify: number_array.rb 1`] = `
 numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9]
 numbers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -18,7 +18,38 @@ numbers
 
 `;
 
-exports[`string_array.rb 1`] = `
+exports[`splats.rb - ruby-verify: splats.rb 1`] = `
+def foo(a = {})
+  some_args = a[:foo] || []
+  [*some_args].map do |i|
+    some_stuff_with i
+  end
+end
+
+first, *, last = [1, 2, 3, 4, 5]
+first, *middle, last = [1, 2, 3, 4]
+first, *rest = [1, 2, 3]
+
+a = [1,2]
+b = [3,4]
+flattened = [*a, *b]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+def foo(a = {})
+  some_args = a[:foo] || []
+  [*some_args].map do |i|
+    some_stuff_with(i)
+  end
+end
+first, *, last = [1, 2, 3, 4, 5]
+first, *middle, last = [1, 2, 3, 4]
+first, *rest = [1, 2, 3]
+a = [1, 2]
+b = [3, 4]
+flattened = [*a, *b]
+
+`;
+
+exports[`string_array.rb - ruby-verify: string_array.rb 1`] = `
 def strings
   %w(
     a
@@ -37,7 +68,7 @@ strings
 
 `;
 
-exports[`symbol_array.rb 1`] = `
+exports[`symbol_array.rb - ruby-verify: symbol_array.rb 1`] = `
 def symbols
   %i(
     a

--- a/tests/array/splats.rb
+++ b/tests/array/splats.rb
@@ -1,0 +1,14 @@
+def foo(a = {})
+  some_args = a[:foo] || []
+  [*some_args].map do |i|
+    some_stuff_with i
+  end
+end
+
+first, *, last = [1, 2, 3, 4, 5]
+first, *middle, last = [1, 2, 3, 4]
+first, *rest = [1, 2, 3]
+
+a = [1,2]
+b = [3,4]
+flattened = [*a, *b]

--- a/vendor/ruby/astexport.rb
+++ b/vendor/ruby/astexport.rb
@@ -140,7 +140,9 @@ class Processor
     remove_token("[")
     remove_space_or_newline
     exprs = []
-    unless nodes.nil?
+    if [*nodes].first == :args_add_star then
+      exprs << visit_args_add_star(nodes)
+    elsif not nodes.nil?
       nodes.each do |exp|
         type, _ = exp
         exprs << visit(exp) unless type == :void_stmt
@@ -450,7 +452,7 @@ class Processor
       {
         ast_type: type,
         left: visit_exps(left),
-        star: visit(star),
+        star: star.nil? ? nil : visit(star),
         right: right.nil? ? nil : visit_exps(right)
       }
     when :lambda


### PR DESCRIPTION
- Handle discarding middle section by omitting variable name when
  destructuring arrays in `:mlhs_add_star` by adding `nil?` check

- Implement support for array constructing syntax by handling special
  `:args_add_star` AST form in `visit_literal_elements`

Resolves #60.